### PR TITLE
기존 있는 회원인지 확인후 user 리턴 

### DIFF
--- a/AIFoodApp/app/src/main/java/com/android/aifoodapp/activity/InitialSurveyActivity.java
+++ b/AIFoodApp/app/src/main/java/com/android/aifoodapp/activity/InitialSurveyActivity.java
@@ -1,5 +1,7 @@
 package com.android.aifoodapp.activity;
 
+import static com.android.aifoodapp.interfaceh.baseURL.url;
+
 import androidx.appcompat.app.AppCompatActivity;
 
 import android.app.Activity;
@@ -59,8 +61,6 @@ public class InitialSurveyActivity extends AppCompatActivity {
     String personName, personGivenName,personEmail,personId ;
     Uri personPhoto ;
 
-    //test
-    TextView test;
 
     GoogleSignInClient mGoogleSignInClient;
 
@@ -119,8 +119,6 @@ public class InitialSurveyActivity extends AppCompatActivity {
         rb_man = findViewById(R.id.rb_man);
         rb_woman = findViewById(R.id.rb_woman);
 
-        //test
-        test = findViewById(R.id.testview2);
     }
 
     private void setting(){
@@ -205,7 +203,6 @@ public class InitialSurveyActivity extends AppCompatActivity {
                 char sex = (survey_result.get("gender")==1)?'M':'F';
                 user account = new user(personId,personName,sex,survey_result.get("age"),
                         survey_result.get("height"),survey_result.get("weight"),survey_result.get("activity_rate"),survey_result.get("target_calorie"));
-                test.setText(personId);
 
                 accounts.put("id",account.getId());
                 accounts.put("nickname",account.getNickname());
@@ -216,12 +213,12 @@ public class InitialSurveyActivity extends AppCompatActivity {
                 accounts.put("activity_index",account.getActivity_index());
                 accounts.put("target_calories",account.getTarget_calories());
 
-                Toast.makeText(activity, account.pringStirng(), Toast.LENGTH_LONG).show();
+                ///Toast.makeText(activity, account.pringStirng(), Toast.LENGTH_LONG).show();
 
                 //핸드폰이용하는 경우 -- https://rateye.tistory.com/1082?category=1026651
-                //String url = "http://192.168.219.102:8080/userSave.do/"; //juhee
+                //String url = "http://192.168.219.103:8080"; //juhee
                 //avd를 이용하는 경우
-                String url = "http://10.0.2.2:8080";
+                //String url = "http://10.0.2.2:8080";
 
                 Retrofit retrofit = new Retrofit.Builder()
                         .baseUrl(url).addConverterFactory(GsonConverterFactory.create()).build();
@@ -244,19 +241,18 @@ public class InitialSurveyActivity extends AppCompatActivity {
                 });
 */
 
-                retrofitAPI.postData(accounts).enqueue(new Callback<user>() {
+                retrofitAPI.postSaveUser(accounts).enqueue(new Callback<user>() {
                     @Override
                     public void onResponse(Call<user> call, Response<user> response) {
                         if(response.isSuccessful()){
                             user data = response.body();
                             Log.d("TestTest","Post 성공");
-                            Log.d("TestTest",data.getNickname());
                         }
                     }
 
                     @Override
                     public void onFailure(Call<user> call, Throwable t) {
-                        Log.d("TestError!!!!","Post 성공");
+                        Log.d("TestError!!!!","Post 실패 ");
                     }
                 });
 

--- a/AIFoodApp/app/src/main/java/com/android/aifoodapp/activity/MainActivity.java
+++ b/AIFoodApp/app/src/main/java/com/android/aifoodapp/activity/MainActivity.java
@@ -23,6 +23,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import com.android.aifoodapp.R;
+import com.android.aifoodapp.domain.user;
 import com.bumptech.glide.Glide;
 
 import com.github.mikephil.charting.charts.RadarChart;
@@ -54,8 +55,8 @@ public class MainActivity<Unit> extends AppCompatActivity {
 
     Activity activity;
     Button btn_logout;
-    TextView tv_userId,tv_userName,tv_userEmail;
-    ImageView tv_userPhoto;
+    TextView tv_userId;
+    //ImageView tv_userPhoto;
 
     GoogleSignInClient mGoogleSignInClient;
 
@@ -74,6 +75,8 @@ public class MainActivity<Unit> extends AppCompatActivity {
     int percent_of_protein;
     int percent_of_fat;
 
+    user user;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -84,6 +87,8 @@ public class MainActivity<Unit> extends AppCompatActivity {
 
         Intent intent = getIntent();
         String userId=intent.getStringExtra("kakao_userNickName");
+        //아래 user 넘겨 받는 코드
+        user = intent.getParcelableExtra("user");
 
         tv_userId.setText(userId);
         btn_logout.setOnClickListener(new View.OnClickListener() {
@@ -114,6 +119,7 @@ public class MainActivity<Unit> extends AppCompatActivity {
         mGoogleSignInClient = GoogleSignIn.getClient(this, gso);
 
 
+        //로그아웃 코드
         btn_logout.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -126,8 +132,10 @@ public class MainActivity<Unit> extends AppCompatActivity {
         });
 
 
-        GoogleSignInAccount acct = GoogleSignIn.getLastSignedInAccount(this);
+        /*사진 이메일등 구글 정보 가져오는*/
+        /*GoogleSignInAccount acct = GoogleSignIn.getLastSignedInAccount(this);
         if (acct != null) {
+
             String personName = acct.getDisplayName();
             String personGivenName = acct.getGivenName();
             String personEmail = acct.getEmail();
@@ -136,20 +144,23 @@ public class MainActivity<Unit> extends AppCompatActivity {
 
             tv_userId.setText(personId);
             tv_userName.setText(personName);
-            tv_userEmail.setText(personEmail);
+            //tv_userEmail.setText(personEmail);
             //Glide 사용 가능
             //https://bumptech.github.io/glide/
-            Glide.with(this).load(String.valueOf(personPhoto)).into(tv_userPhoto);
+            //Glide.with(this).load(String.valueOf(personPhoto)).into(tv_userPhoto);
             //tv_userPhoto.setImageIcon(Icon.createWithContentUri(personPhoto));
 
-        }
+        }*/
         /*juhee modify--fin*/
 
+        //구글 로그인 닉네임
+        tv_userId.setText(user.getNickname());
 
     }
+
+    //Todo 구글 로그인을 계속 연동해서 사용할지 아니면 토큰만 써서 할지 결정
     private void signOut() {
-        mGoogleSignInClient.signOut()
-                .addOnCompleteListener(this, new OnCompleteListener<Void>() {
+        mGoogleSignInClient.signOut().addOnCompleteListener(this, new OnCompleteListener<Void>() {
                     @Override
                     public void onComplete(@NonNull Task<Void> task) {
                         Toast.makeText(MainActivity.this,"Signed Out ok ",Toast.LENGTH_LONG).show();
@@ -163,10 +174,6 @@ public class MainActivity<Unit> extends AppCompatActivity {
         activity = this;
         btn_logout = findViewById(R.id.btn_logout);
         tv_userId=findViewById(R.id.tv_userId);
-
-        tv_userPhoto=findViewById(R.id.tv_userPhoto);
-        tv_userEmail=findViewById(R.id.tv_userEmail);
-        tv_userName=findViewById(R.id.tv_userName);
 
         layout_date = findViewById(R.id.layout_date);
         tv_month = findViewById(R.id.tv_month);
@@ -205,6 +212,7 @@ public class MainActivity<Unit> extends AppCompatActivity {
         @Override
         public void onClick(View view) {
             Intent intent = new Intent(activity, UserSettingActivity.class);
+            intent.putExtra("user",user);
             startActivity(intent);
         }
     };

--- a/AIFoodApp/app/src/main/java/com/android/aifoodapp/activity/UserSettingActivity.java
+++ b/AIFoodApp/app/src/main/java/com/android/aifoodapp/activity/UserSettingActivity.java
@@ -1,6 +1,7 @@
 package com.android.aifoodapp.activity;
 
 import android.app.Activity;
+import android.content.Intent;
 import android.os.Bundle;
 import android.widget.ImageView;
 import android.widget.TextView;
@@ -8,6 +9,7 @@ import android.widget.TextView;
 import androidx.appcompat.app.AppCompatActivity;
 
 import com.android.aifoodapp.R;
+import com.android.aifoodapp.domain.user;
 
 public class UserSettingActivity extends AppCompatActivity {
 
@@ -22,15 +24,31 @@ public class UserSettingActivity extends AppCompatActivity {
     TextView tv_kg;
     TextView tv_bmi;
 
+    com.android.aifoodapp.domain.user user;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_usersetting);
         initialize();
 
-
+        Intent intent = getIntent();
+        user = intent.getParcelableExtra("user");
+        settingText();
     }
 
+    private void settingText(){
+        //iv_profile
+        tv_userName.setText(user.getNickname());
+        tv_userIdInfo.setText(user.getId());
+        //tv_modifyInfo
+        //tv_modifyPwd
+       // tv_age.setText(user.getAge());
+        //tv_height.setText(user.getHeight());
+        //tv_kg.setText(user.getWeight());
+        //tv_bmi
+
+    }
 
     //변수 초기화
     private void initialize(){

--- a/AIFoodApp/app/src/main/java/com/android/aifoodapp/domain/user.java
+++ b/AIFoodApp/app/src/main/java/com/android/aifoodapp/domain/user.java
@@ -1,8 +1,11 @@
 package com.android.aifoodapp.domain;
 
+import android.os.Parcel;
+import android.os.Parcelable;
+
 import com.google.gson.annotations.SerializedName;
 
-public class user {
+public class user implements Parcelable {
     @SerializedName("id")
     private String id;
     @SerializedName("nickname")
@@ -37,6 +40,18 @@ public class user {
 
     }
 
+
+    public static final Creator<user> CREATOR = new Creator<user>() {
+        @Override
+        public user createFromParcel(Parcel in) {
+            return new user(in);
+        }
+
+        @Override
+        public user[] newArray(int size) {
+            return new user[size];
+        }
+    };
 
     public String getId(){
         return id;
@@ -110,7 +125,46 @@ public class user {
         return  "user"+id+"  "+nickname+"   "+sex + "   " + getActivity_index();
     }
 
+    //TODO 해당부분에서 자잘한 에러 나는듯 확인 필요
+    protected user(Parcel in){
+        id=in.readString();
+        nickname=in.readString();
+        sex = (in.readString()!=null)?in.readString().charAt(0):'N';
+        age=in.readInt();
+        height= in.readInt();
+        weight=in.readInt();
+        activity_index= in.readInt();
+        target_calories=in.readInt();
+        //profile
+    }
 
+    public static final Creator<user> USER_CREATOR = new Creator<user>() {
+        @Override
+        public user createFromParcel(Parcel parcel) {
+            return new user(parcel);
+        }
 
+        @Override
+        public user[] newArray(int size) {
+            return new user[size];
+        }
+    };
 
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel parcel, int i) {
+        parcel.writeString(id);
+        parcel.writeString(nickname);
+        parcel.writeInt((int) sex);
+        parcel.writeInt(age);
+        parcel.writeInt(height);
+        parcel.writeInt(weight);
+        parcel.writeInt(activity_index);
+        parcel.writeInt(target_calories);
+        //profile
+    }
 }

--- a/AIFoodApp/app/src/main/java/com/android/aifoodapp/interfaceh/NullOnEmptyConverterFactory.java
+++ b/AIFoodApp/app/src/main/java/com/android/aifoodapp/interfaceh/NullOnEmptyConverterFactory.java
@@ -1,0 +1,29 @@
+package com.android.aifoodapp.interfaceh;
+
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+import okhttp3.ResponseBody;
+import retrofit2.Converter;
+import retrofit2.Retrofit;
+
+//오는 정보가 0이면 null로 바꿔주는 클래스
+public class NullOnEmptyConverterFactory extends Converter.Factory {
+
+    @Override
+    public Converter<ResponseBody, ?> responseBodyConverter(Type type, Annotation[] annotations, Retrofit retrofit)
+    {
+        final Converter<ResponseBody, ?> delegate = retrofit.nextResponseBodyConverter(this, type, annotations);
+        return new Converter<ResponseBody, Object>() {
+            @Override
+            public Object convert(ResponseBody body) throws IOException
+            {
+                if (body.contentLength() == 0) {
+                    return null;
+                }
+                return delegate.convert(body);
+            }
+        };
+    }
+}

--- a/AIFoodApp/app/src/main/java/com/android/aifoodapp/interfaceh/RetrofitAPI.java
+++ b/AIFoodApp/app/src/main/java/com/android/aifoodapp/interfaceh/RetrofitAPI.java
@@ -13,11 +13,11 @@ import retrofit2.http.POST;
 import retrofit2.http.Query;
 
 public interface RetrofitAPI {
-    @GET("/posts")
-    Call<List<user>> getData(@Query("userID")String id);
+    @GET("/checkUserId.do")
+    Call<user> getUser(@Query("id") String id);
 
     @FormUrlEncoded
     @POST("/userSave.do")
-    Call<user> postData(@FieldMap HashMap<String, Object>param);
+    Call<user> postSaveUser(@FieldMap HashMap<String, Object>param);
 
 }

--- a/AIFoodApp/app/src/main/java/com/android/aifoodapp/interfaceh/baseURL.java
+++ b/AIFoodApp/app/src/main/java/com/android/aifoodapp/interfaceh/baseURL.java
@@ -1,0 +1,8 @@
+package com.android.aifoodapp.interfaceh;
+
+public interface baseURL {
+    //핸드폰이용하는 경우 -- https://rateye.tistory.com/1082?category=1026651
+    String url = "http://192.168.219.103:8080"; //juhee
+    //avd를 이용하는 경우
+    //String url = "http://10.0.2.2:8080";
+}

--- a/AIFoodApp/app/src/main/res/main/layout/activity_initial_survey.xml
+++ b/AIFoodApp/app/src/main/res/main/layout/activity_initial_survey.xml
@@ -95,36 +95,6 @@
 
                 </LinearLayout>
 
-                <!-- TEst-->
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:orientation="horizontal">
-
-                    <TextView
-                        android:layout_width="0dp"
-                        android:layout_height="match_parent"
-                        android:layout_weight="2"
-                        android:gravity="center_vertical"
-                        android:text="■ Test(email)"
-                        android:textColor="#1E1E1E" />
-
-
-                    <TextView
-                        android:id="@+id/testview2"
-                        android:layout_width="0dp"
-                        android:layout_height="match_parent"
-                        android:layout_weight="2"
-                        android:ems="10"
-                        android:gravity="center"
-                        android:text = "Test"
-                        android:inputType="number" />
-
-
-                </LinearLayout>
-
-                <!--test Fin-->
-
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"

--- a/AIFoodApp/app/src/main/res/main/layout/activity_main.xml
+++ b/AIFoodApp/app/src/main/res/main/layout/activity_main.xml
@@ -15,24 +15,6 @@ tools:context=".activity.MainActivity">
         android:orientation="vertical"
         android:padding="10dp">
 
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
-
-            <TextView
-                android:id="@+id/tv_userName"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginRight="11dp"
-                android:text="tv_userName" />
-
-            <TextView
-                android:id="@+id/tv_userEmail"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="tv_userEmail" />
-        </LinearLayout>
 
         <LinearLayout
             android:layout_width="match_parent"


### PR DESCRIPTION
1. test용 출력화면 제거 <main,intial survey>
2. 처음 로그인 할때 회원 정보 없으면 -> intial page로, 회원 정보 있으면 -> mainpage 로
(아직 구글 정보만 연결함, user 객체에 저장해서 회원 정보 관리하는게 좋을것 같아서 그렇게 만들어둠, 카카오도 여기에 저장해서 통합으로 관리하는게 좋을것 같습니다.)
3. 로그인 정확하게 된건지 확인한다고 임시로 회원정보 변경 페이지에 받은 정보들 세팅하게 함( 문제는 어째서 인지 id,닉네임 제외하고는 써지지 않음.. 확인 필요, 비밀번호도 추가할거면 디비테이블에 넣을지 회의 해야할듯)
4. url (로컬 서버)연결 부분도 아예 baseURL클래스를 만들어서 거기서만 수정하면 모든 클래스에서 변경없이 사용할수 있게 했음, intial page 말고 각자 baseURL 코드를 아래에 써두고 주석처리 해서 서로 깃에 올릴때 삭제 안되도록 하여 개발하는게 좋을것 같습니다!